### PR TITLE
PSR12対応、Swagger対応、他いろいろ

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose.yml
 
+FQDN=localhost
 MYSQL_DATABASE=stock_performance
 MYSQL_USER=stock_user
 MYSQL_PASSWORD=NtdEboMNQlCpDUL7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
             - php-fpm-socket:/var/run/php-fpm
             - ./cake_app:/var/www/cake_app
         environment:
+            FQDN: $FQDN
             MYSQL_DATABASE: $MYSQL_DATABASE
             MYSQL_USER: $MYSQL_USER
             MYSQL_PASSWORD: $MYSQL_PASSWORD

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,11 +1,13 @@
-FROM nginx:1.20-alpine
+FROM nginx:1.21-alpine
 SHELL ["/bin/ash", "-oeux", "pipefail", "-c"]
 
 ENV TZ=Asia/Tokyo
 
-RUN adduser -H -S www-data -u 1000 && \
-    apk update && \
-    apk add --update --no-cache --virtual=.build-dependencies g++ tzdata
+RUN apk update && \
+    apk add --update --no-cache --virtual=.build-dependencies g++ tzdata shadow && \
+    groupmod www-data -g 1000 && \
+    useradd -u 1000 -g www-data www-data && \
+    apk del .build-dependencies
 
 COPY ./conf.d/default.conf /etc/nginx/conf.d/default.conf
 COPY ./nginx.conf /etc/nginx/nginx.conf

--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -7,7 +7,7 @@ server {
 }
 
 server {
-    listen 443 ssl;
+    listen 443 ssl http2;
     root /var/www/cake_app/webroot;
 
     ssl_certificate /etc/nginx/ssl/server.crt;


### PR DESCRIPTION
 - phpstanのレベルを7→8に移行
 - nginxコンテナについてhttp2対応、nginx最新化
 - appコンテナにgraphvizをインストールするよう修正
 - Swagger対応について既存のプロジェクトでは利用しない
 - phpcsの定義について最新のcakephp/cakephp-codesnifferを見るよう修正
 - Swagger対応に伴いCsrfミドルウェアについてアプリケーション全体への適用をやめ、ルーティング内で定義するよう変更